### PR TITLE
Change "const" to "var" so that IE10 does not crash on syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,6 @@ function clean(values) {
 
 /* Return nothing. */
 function empty(token) {
-  const value = token.value.replace(/<(?:.|\n)*?>/gm, '');
+  var value = token.value.replace(/<(?:.|\n)*?>/gm, '');
   return {type: 'text', value: value};
 }


### PR DESCRIPTION
I think this might be a typo since `var` is used throughout the file execpt for the last function where `const` is used. After changing to `var` IE10 was happy.
